### PR TITLE
fixed oversight with preventOverpayingForVendorItems

### DIFF
--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -1649,7 +1649,7 @@ void AuctionHouseBot::PopulateVendorItemsPrices()
     uint32_t numItems = f[0].Get<uint32>();
     vendorItemsPrices = std::vector<uint32>(numItems, UINT32_MAX);
     
-    QueryResult result = WorldDatabase.Query("SELECT v.entry, MIN(v.SellPrice) AS SellPrice FROM item_template v JOIN npc_vendor p ON v.entry = p.item GROUP BY v.entry");
+    QueryResult result = WorldDatabase.Query("SELECT v.entry, MIN(v.SellPrice) AS SellPrice FROM item_template v JOIN npc_vendor p ON v.entry = p.item WHERE v.class != {} GROUP BY v.entry", ITEM_CLASS_TRADE_GOODS);
     if (result)
     {
         do


### PR DESCRIPTION
## Changes Proposed:
- The original SQL query to look for items that are sold by vendors also included many Trade Goods (142). Since  many of these Trade Goods have a BuyPrice that is much lower than what players will try to sell them for on the AH, the BuyerBot never buys these items.   

## Tests Performed:
- Successfully listed and sold Thick Leather, Wool Cloth, Linen Cloth, Dreamfoil, Earthroot, Tin Ore  
- Still unable to sell other Vendor items like Refreshing Spring Water, etc. 👍   

I guess this was possible in Retail, but probably the vendors that sell these items only do so in limited quantities. I'm not 100% certain that all of these items are only available in limited quantities, but if you'd like to check the affected items, here's a query:  

`SELECT v.entry, v.name, v.subclass, MIN(v.SellPrice) AS SellPrice FROM item_template v JOIN npc_vendor p ON v.entry = p.item WHERE v.class = 7 GROUP BY v.entry, v.subclass ORDER BY v.subclass, v.entry;`  
