### PR TITLE
Added additional AdvancedListingRules.UseDropRates settings

### DIFF
--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -85,32 +85,58 @@ AuctionHouseBot.ListingExpireTimeInSecondsMax = 86400
 #    AuctionHouseBot.AdvancedListingRules.UseDropRates.Enabled
 #        Enable/Disable the Seller using items' in-game drop rates from Enemies
 #        and GameObjects to determine the probability of listing them on the AH.
-#        Attempts to simulate "live" AHs by making very powerful items appear less often.
+#        This makes rare items appear less frequently on the AH.
+#        How it works: Each time an enabled item Category/Quality is selected to post an auction,
+#        a number is rolled between 0-100. Based on this roll, a Tier is chosen based on
+#        UseDropRates.TiersConfig, then a random item from that rarity tier is listed on the AH.
 #        This setting respects ListProportion config. It can also result in more duplicate
 #        items appearing on the AH due to higher-drop-rate items being selected more often.
 #        Crafted items may also appear more often since their drop rate is effectively 100%.
 #    Default: false (disabled)
 #
-#    AuctionHouseBot.AdvancedListingRules.UseDropRates.MinQuality
-#        The minimum quality that should be included by AdvancedListingRules.UseDropRates.
-#        Value should be the integer corresponding to the desired minimum rarity.
-#        Examples: Setting to 3 will apply to Rare, Epic, Legendary, and Heirloom.
-#          Setting to 1 will apply to Common, Uncommon, Rare, Epic, Legendary, and Heirloom.
-#        (0) Poor, (1) Common, (2) Uncommon, (3) Rare, (4) Epic, (5) Legendary, (6) Heirloom
-#    Default: 3
-#
 #    AuctionHouseBot.Seller.AdvancedListingRules.UseDropRates.<Category>
 #        Toggle AdvancedListingRules.UseDropRates behavior for individual category.
 #        Only applied if AdvancedListingRules.UseDropRates.Enabled is true.
 #    Default: true (enabled)
+#
+#    AuctionHouseBot.AdvancedListingRules.UseDropRates.<Category>.AffectedQualities
+#        The qualities that should be affected by AdvancedListingRules.UseDropRates.
+#        Value should be a string of comma separated numbers corresponding to the desired qualities.
+#        Examples: Setting to 2,3,5 will apply to Uncommon, Rare, and Legendary.
+#          Setting to 4 will apply only to Epic.
+#        (0) Poor, (1) Common, (2) Uncommon, (3) Rare, (4) Epic, (5) Legendary, (6) Heirloom
+#    Default: 2,3,4,5
+#
+#    AuctionHouseBot.AdvancedListingRules.UseDropRates.TiersConfig
+#        The thresholds that define item drop rate tiers.
+#        Value should be a string of comma-separated numbers between 0 and 100.
+#        Each number creates a tier for items whose drop rate falls within that range.
+#        The order of numbers in the string does not need to be sorted; they will be
+#        interpreted in descending order. However, you may find it easier to read when sorted.
+#        Whitespace is also ignored.
+#        Example: Setting to 50,10,5 will create 3 tiers:
+#          - 50–100%: items with drop rate 50% or higher
+#          - 10–50%: items with drop rate between 10% and 50%
+#          - 0–5%: items with drop rate 0–5%
+#    Default: 50, 10, 5, 2, 1, 0.5, 0.2, 0.1, 0.05, 0.02, 0.01, 0.005
+#
+#    AuctionHouseBot.AdvancedListingRules.UseDropRates.DisabledItemIDs
+#        Comma separated list of itemIDs to exclude from having its drop rate influence its AH availability
+#        Ranges using a dash (-) can also be used.
 ###############################################################################
 
 AuctionHouseBot.AdvancedListingRules.UseDropRates.Enabled = false
-AuctionHouseBot.AdvancedListingRules.UseDropRates.MinQuality = 2
 
 AuctionHouseBot.AdvancedListingRules.UseDropRates.Weapon = true
 AuctionHouseBot.AdvancedListingRules.UseDropRates.Armor  = true
 AuctionHouseBot.AdvancedListingRules.UseDropRates.Recipe = true
+
+AuctionHouseBot.AdvancedListingRules.UseDropRates.Weapon.AffectedQualities = 2,3,4,5
+AuctionHouseBot.AdvancedListingRules.UseDropRates.Armor.AffectedQualities  = 2,3,4,5
+AuctionHouseBot.AdvancedListingRules.UseDropRates.Recipe.AffectedQualities = 2,3,4,5
+
+AuctionHouseBot.AdvancedListingRules.UseDropRates.TiersConfig = 50, 10, 5, 2, 1, 0.5, 0.2, 0.1, 0.05, 0.02, 0.01, 0.005
+AuctionHouseBot.AdvancedListingRules.UseDropRates.DisabledItemIDs = 
 
 ###############################################################################
 #    AuctionHouseBot.MaxBuyoutPriceInCopper

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -279,12 +279,16 @@ private:
     std::set<uint32> ListedItemIDExceptionItems;
     bool PreventOverpayingForVendorItems;
     std::unordered_map<uint32, double> CachedItemDropRates;
-    std::vector<uint32> ItemTiersByClassAndQuality[17][7][11]; // [Classes][Qualities][Tiers]
+    std::vector<std::vector<std::vector<std::vector<uint32>>>> ItemTiersByClassAndQuality;  // [Classes][Qualities][Tiers] .. [17][7][configurable]
+    std::map<double, int, std::greater<double>> DropRatesToTierMap;
+    std::set<uint32> AdvancedListingRuleUseDropRatesExceptionItems;
     bool AdvancedListingRuleUseDropRatesEnabled;
     bool AdvancedListingRuleUseDropRatesWeaponEnabled;
     bool AdvancedListingRuleUseDropRatesArmorEnabled;
     bool AdvancedListingRuleUseDropRatesRecipeEnabled;
-    int AdvancedListingRuleUseDropRatesMinQuality;
+    std::set<uint32> AdvancedListingRuleUseDropRatesWeaponAffectedQualities;
+    std::set<uint32> AdvancedListingRuleUseDropRatesArmorAffectedQualities;
+    std::set<uint32> AdvancedListingRuleUseDropRatesRecipeAffectedQualities;
     std::unordered_set<uint32> QuestRewardItemIDs;
 
     FactionSpecificAuctionHouseConfig AllianceConfig;
@@ -316,18 +320,21 @@ public:
     void SetBuyingBotBuyCandidatesPerBuyCycle();
     void GetConfigMinAndMax(std::string config, uint32& min, uint32& max);
     void AddCharacters(std::string characterGUIDString);
-    void AddItemIDsFromString(std::set<uint32>& workingItemIDSet, std::string itemString, const char* parentOperationName);
-    void AddToItemIDSet(std::set<uint32>& workingItemIDSet, uint32 itemID, const char* parentOperationName);
+    void ParseNumberListToSet(std::set<uint32>& workingItemIDSet, std::string itemString, const char* parentOperationName);
+    void AddToNumberListSet(std::set<uint32>& workingItemIDSet, uint32 itemID, const char* parentOperationName);
     const char* GetQualityName(ItemQualities quality);
     const char* GetCategoryName(ItemClass category);
     uint32 GetStackSizeForItem(ItemTemplate const* itemProto) const;
     void CalculateItemValue(ItemTemplate const* itemProto, uint64& outBidPrice, uint64& outBuyoutPrice);
     void PopulateItemDropChances();
-    std::string GetAdvancedListingRuleUseDropRatesEnabledCategoriesString();
+    void PopulateItemDropChancesForCategoryAndQuality(ItemClass category, std::string qualities);
+    void InitializeAdvancedListingRuleUseDropRatesTiers();
     void PopulateQuestRewardItemIDs();
     bool IsItemQuestReward(uint32 itemID);
     bool IsItemCrafted(uint32 itemID);
+    bool IsItemCategoryQualityInDBDropRatesConfig(ItemTemplate const* proto);
     bool IsItemEligibleForDBDropRates(ItemTemplate const* proto);
+    bool HandleAdvancedListingRuleUseDropRates(ItemTemplate const*& proto);
     int GetItemDropChanceTier(double dropRate);
     float GetAdvancedPricingMultiplier(ItemTemplate const* itemProto);
     ItemTemplate const* GetProducedItemFromRecipe(ItemTemplate const* recipeItemTemplate);

--- a/src/AuctionHouseBotScript.cpp
+++ b/src/AuctionHouseBotScript.cpp
@@ -181,6 +181,15 @@ public:
         sConfigMgr->LoadModulesConfigs(true, false);
         AuctionHouseBot::instance()->InitializeConfiguration();
         AuctionHouseBot::instance()->PopulateItemCandidatesAndProportions();
+
+        if (sConfigMgr->GetOption<bool>("AuctionHouseBot.AdvancedListingRules.UseDropRates.Enabled", true))
+        {
+            auctionbot->PopulateQuestRewardItemIDs();
+            auctionbot->PopulateItemDropChances();
+        }
+
+        LOG_INFO("module", "AuctionHouseBot: Config reloaded.");
+        handler->PSendSysMessage("AuctionHouseBot: Config reloaded.");        
         return true;
     }
 


### PR DESCRIPTION
### Changes Proposed:
- Separate `AdvancedListingRules.UseDropRates` Category and Quality settings
- Enable fine-grained UseDropRates Quality configuration, per enabled Category
- Expose UseDropRates' Tiers configuration, allows for variable number of tiers
- Optimized some SQL queries; reduces time to run `PopulateItemDropChances()` from ~4s to ~1.8s on my machine
- Rename `AddItemIDsFromString()` to `ParseNumberListToSet()` since the functionality can be convenient in other contexts

### Tests Performed:
- Builds without errors
- Independently tested AffectedQualities per Category with a variety of enabled Qualities
- Tested several configurations of varying length for TiersConfig, verified number of items in resulting tiers changed accordingly
- Verified items included in DisabledItemIDs appear in AH more frequently due to no influence of UseDropRates

### How to Test the Changes:
1. Enable `AdvancedListingRules.UseDropRates` and `AuctionHouseBot.DEBUG`
2. In the worldserver logs, observe counts for each Category/Quality/Tier, note number of tiers and items in each
3. Change TiersConfig, enabled categories/qualities, reload config and repeat Step 2. Output should be different.
4. Add some itemID to `DisabledItemIDs` (e.g. 873 is `Staff of Jordan`), reload config and cycle a few thousand items. It should appear in the AH eventually. Remove it from `DisabledItemIDs`, and it should very rarely appear. Alternatively, you could add some additional logging during `PopulateItemDropChancesForCategoryAndQuality()` and log its drop chance when `proto->ItemID == 873`.
<br>
As always, happy to change anything 👍  Just let me know