### PR TITLE
Added UseDropRates.MinDropRate + other fixes

### DIFF
--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -94,7 +94,7 @@ AuctionHouseBot.ListingExpireTimeInSecondsMax = 86400
 #        Crafted items may also appear more often since their drop rate is effectively 100%.
 #    Default: false (disabled)
 #
-#    AuctionHouseBot.Seller.AdvancedListingRules.UseDropRates.<Category>
+#    AuctionHouseBot.AdvancedListingRules.UseDropRates.<Category>
 #        Toggle AdvancedListingRules.UseDropRates behavior for individual category.
 #        Only applied if AdvancedListingRules.UseDropRates.Enabled is true.
 #    Default: true (enabled)
@@ -106,6 +106,12 @@ AuctionHouseBot.ListingExpireTimeInSecondsMax = 86400
 #          Setting to 4 will apply only to Epic.
 #        (0) Poor, (1) Common, (2) Uncommon, (3) Rare, (4) Epic, (5) Legendary, (6) Heirloom
 #    Default: 2,3,4,5
+#
+#    AuctionHouseBot.AdvancedListingRules.UseDropRates.MinDropRate
+#        The minimum drop rate any affected item can have.
+#        Some items can have extremely low drop rates in the DB (e.g. 0.00006), so
+#        this setting will raise those items' drop rate to this value.
+#    Default: 0.005
 #
 #    AuctionHouseBot.AdvancedListingRules.UseDropRates.TiersConfig
 #        The thresholds that define item drop rate tiers.
@@ -135,6 +141,7 @@ AuctionHouseBot.AdvancedListingRules.UseDropRates.Weapon.AffectedQualities = 2,3
 AuctionHouseBot.AdvancedListingRules.UseDropRates.Armor.AffectedQualities  = 2,3,4,5
 AuctionHouseBot.AdvancedListingRules.UseDropRates.Recipe.AffectedQualities = 2,3,4,5
 
+AuctionHouseBot.AdvancedListingRules.UseDropRates.MinDropRate = 0.005
 AuctionHouseBot.AdvancedListingRules.UseDropRates.TiersConfig = 50, 10, 5, 2, 1, 0.5, 0.2, 0.1, 0.05, 0.02, 0.01, 0.005
 AuctionHouseBot.AdvancedListingRules.UseDropRates.DisabledItemIDs = 
 

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -289,6 +289,7 @@ private:
     std::set<uint32> AdvancedListingRuleUseDropRatesWeaponAffectedQualities;
     std::set<uint32> AdvancedListingRuleUseDropRatesArmorAffectedQualities;
     std::set<uint32> AdvancedListingRuleUseDropRatesRecipeAffectedQualities;
+    float AdvancedListingRuleUseDropRatesMinDropRate;
     std::unordered_set<uint32> QuestRewardItemIDs;
 
     FactionSpecificAuctionHouseConfig AllianceConfig;

--- a/src/AuctionHouseBotScript.cpp
+++ b/src/AuctionHouseBotScript.cpp
@@ -169,6 +169,8 @@ public:
         LOG_INFO("module", "AuctionHouseBot: Updating Auction House...");
         handler->PSendSysMessage("AuctionHouseBot: Updating Auction House...");
         AuctionHouseBot::instance()->Update();
+        LOG_INFO("module", "AuctionHouseBot: Auction House Updated.");
+        handler->PSendSysMessage("AuctionHouseBot: Auction House Updated.");
         return true;
     }
 
@@ -198,6 +200,9 @@ public:
         LOG_INFO("module", "AuctionHouseBot: Emptying Auction House...");
         handler->PSendSysMessage("AuctionHouseBot: Emptying Auction House...");
         AuctionHouseBot::instance()->EmptyAuctionHouses();
+        AuctionHouseBot::instance()->CleanupExpiredAuctionItems(); // Must go after EmptyAuctionHouses()
+        LOG_INFO("module", "AuctionHouseBot: Auction Houses Emptied.");
+        handler->PSendSysMessage("AuctionHouseBot: Auction Houses Emptied.");
         return true;
     }
 


### PR DESCRIPTION
### Primary Changes:
- Add AdvancedListingRules.UseDropRates.MinDropRate, so admins can set a floor to item drop rates

### Secondary Changes:  
- Fixed a typo on "dangling Reference" items. Using `AVG` can result in items having inflated drop prices due to how calculation works. If the item is part of a group and doesn't have a drop rate explicitly defined, the code infers a rate by dividing 1/(the number of items in the items group). Sometimes there are only a couple items in the group, so a drop chance of 0.33 or 0.5 (for example) is possible. When other sources in the DB have rates much lower (<= 0.01), using MIN provides more "accurate" results. In any case, the greater of all sources is eventually used as the final drop rate, but this keeps things "fair".
- Added `overwriteDropRate` flag to drop rate handler lambda & set danglingReferenceResult's case to `false`. This set of items is really only supposed to be a "catch all" for items whose reference_loot_template isn't assigned to any creature, and their drop rate wasn't already set by other valid sources. Skipping these cases prevents accidental inflation of drop rate for some items.
- Moved `CleanupExpiredAuctionItems()` to the `.ahbot empty` call since I realized emptying the auction house is the only way to create dangling Expired Auctions, and there's no need to call it every `Update()` cycle
- Added extra logging to `.ahbot` commands to show completion
- Fixed [a typo in the .conf.dist](https://github.com/NathanHandley/mod-ah-bot/pull/38#issuecomment-3401376856)

### Tests Performed:
- Builds without errors
- Verified with logging that items with drop rate < `UseDropRates.MinDropRate` have their drop rate raised to this value


### How to Test the Changes:
1. Set `UseDropRates.MinDropRate` to `0.005`, update many items in the AH, observe rare items' scarcity
2. Set `UseDropRates.MinDropRate` to `95`, update many items in the AH, observe rare items are abundant
