### PR TITLE
Improved UseDropRates item selection logic, Removed duplicates from ItemTiersByClassAndQuality

### DIFF
--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -1101,10 +1101,10 @@ bool AuctionHouseBot::HandleAdvancedListingRuleUseDropRates(ItemTemplate const*&
     double r = 100.0 * (urand(0, INT32_MAX) / static_cast<double>(INT32_MAX));
     int tier = GetItemDropChanceTier(r);
 
-    // If chosen tier is empty, search rarer tiers until not empty
+    // If chosen tier is empty, search more common tiers until not empty
     auto& tierBuckets = ItemTiersByClassAndQuality[proto->Class][proto->Quality];
-    while (tierBuckets[tier].empty() && tier < 10) {
-        tier++;
+    while (tierBuckets[tier].empty() && tier > 0) {
+        tier--;
     }
 
     // Pull a random item from selected rarity tier
@@ -1197,11 +1197,11 @@ void AuctionHouseBot::PopulateItemDropChances()
                 for (size_t k = 0; k < tiers.size(); ++k)
                 {
                     const auto& items = tiers[k];
-                    if (i == 2)
-                        LOG_INFO("module", "Armor Count: {} Tier {} has {} items", GetQualityName((ItemQualities)j), k, items.size());
-                    if (i == 4)
+                    if (i == ITEM_CLASS_WEAPON)
                         LOG_INFO("module", "Weapon Count: {} Tier {} has {} items", GetQualityName((ItemQualities)j), k, items.size());
-                    if (i == 9)
+                    if (i == ITEM_CLASS_ARMOR)
+                        LOG_INFO("module", "Armor Count: {} Tier {} has {} items", GetQualityName((ItemQualities)j), k, items.size());
+                    if (i == ITEM_CLASS_RECIPE)
                         LOG_INFO("module", "Recipe Count: {} Tier {} has {} items", GetQualityName((ItemQualities)j), k, items.size());
                 }
             }
@@ -1405,6 +1405,14 @@ void AuctionHouseBot::PopulateItemDropChancesForCategoryAndQuality(ItemClass cat
             }
         }
     }
+
+    // Remove duplicates
+    for (auto& byClass : ItemTiersByClassAndQuality)
+        for (auto& byQuality : byClass)
+            for (auto& byTier : byQuality) {
+                std::sort(byTier.begin(), byTier.end());
+                byTier.erase(std::unique(byTier.begin(), byTier.end()), byTier.end());
+            }
 }
 
 void AuctionHouseBot::InitializeAdvancedListingRuleUseDropRatesTiers()


### PR DESCRIPTION
### Changes Proposed:
- Rather than selecting "rarer" item buckets until a non-empty one is found, search "more common" item buckets. This way if `ListedItemLevelRestrict` is enabled and there are few items to select from, rare items retain their rarity
- Removed duplicates from ItemTiersByClassAndQuality
- Fixed a debugging output issue (weapons were labeled as armor, and vice versa). Used constants to avoid future confusion

### Tests Performed:
- Builds without errors
- When all searched buckets are empty, logic skips adding an item gracefully

### How to Test the Changes:
1. Set `ListedItemLevelRestrict.Enabled` = `true`
2. Set `ListedItemLevelRestrict.MaxItemLevel` = `80` (roughly the ilvl cap of vanilla items)
3. Cycle many items through the AH. Filter Epic Weapons 1-60, items like Staff of Jordan, Fiery War Axe, Taran Icebreaker should appear very rarely (as intended)
