### PR TITLE
Improved logging for some cases of ParseNumberListToSet, Fixed erroneous duplicate entries error logging

### DIFF
--- a/conf/mod_ahbot.conf.dist
+++ b/conf/mod_ahbot.conf.dist
@@ -194,6 +194,9 @@ AuctionHouseBot.BuyoutBelowVendorVariationAddPercent = 0.25
 #    AuctionHouseBot.<faction>.MinItems
 #    AuctionHouseBot.<faction>.MaxItems
 #        The minimum and maximum number of items to post on that auction house
+#    Note: If you have AllowTwoSide.Interaction.Auction enabled in your AzerothCore's
+#        worldserver.conf, then only the Neutral AH will appear to fill in the
+#        database. Auctions will still appear in non-Neutral AH.
 #    Default: 15000 for both
 ###############################################################################
 

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -1829,9 +1829,12 @@ void AuctionHouseBot::InitializeConfiguration()
     AdvancedListingRuleUseDropRatesRecipeEnabled = sConfigMgr->GetOption<bool>("AuctionHouseBot.AdvancedListingRules.UseDropRates.Recipe", true);
     AdvancedListingRuleUseDropRatesMinDropRate = sConfigMgr->GetOption<float>("AuctionHouseBot.AdvancedListingRules.UseDropRates.MinDropRate", 0.005);
     if (AdvancedListingRuleUseDropRatesMinDropRate < 0 || AdvancedListingRuleUseDropRatesMinDropRate > 100) AdvancedListingRuleUseDropRatesMinDropRate = 0.005;
-    ParseNumberListToSet(AdvancedListingRuleUseDropRatesWeaponAffectedQualities, sConfigMgr->GetOption<std::string>("AuctionHouseBot.AdvancedListingRules.UseDropRates.Weapon.AffectedQualities", "2,3,4,5"), "");
-    ParseNumberListToSet(AdvancedListingRuleUseDropRatesArmorAffectedQualities, sConfigMgr->GetOption<std::string>("AuctionHouseBot.AdvancedListingRules.UseDropRates.Armor.AffectedQualities", "2,3,4,5"), "");
-    ParseNumberListToSet(AdvancedListingRuleUseDropRatesRecipeAffectedQualities, sConfigMgr->GetOption<std::string>("AuctionHouseBot.AdvancedListingRules.UseDropRates.Recipe.AffectedQualities", "2,3,4,5"), "");
+    AdvancedListingRuleUseDropRatesWeaponAffectedQualities.clear();
+    AdvancedListingRuleUseDropRatesArmorAffectedQualities.clear();
+    AdvancedListingRuleUseDropRatesRecipeAffectedQualities.clear();
+    ParseNumberListToSet(AdvancedListingRuleUseDropRatesWeaponAffectedQualities, sConfigMgr->GetOption<std::string>("AuctionHouseBot.AdvancedListingRules.UseDropRates.Weapon.AffectedQualities", "2,3,4,5"), "AdvancedListingRules.UseDropRates.Weapon.AffectedQualities");
+    ParseNumberListToSet(AdvancedListingRuleUseDropRatesArmorAffectedQualities, sConfigMgr->GetOption<std::string>("AuctionHouseBot.AdvancedListingRules.UseDropRates.Armor.AffectedQualities", "2,3,4,5"), "AdvancedListingRules.UseDropRates.Armor.AffectedQualities");
+    ParseNumberListToSet(AdvancedListingRuleUseDropRatesRecipeAffectedQualities, sConfigMgr->GetOption<std::string>("AuctionHouseBot.AdvancedListingRules.UseDropRates.Recipe.AffectedQualities", "2,3,4,5"), "AdvancedListingRules.UseDropRates.Recipe.AffectedQualities");
     AdvancedListingRuleUseDropRatesExceptionItems.clear();
     ParseNumberListToSet(AdvancedListingRuleUseDropRatesExceptionItems, sConfigMgr->GetOption<std::string>("AuctionHouseBot.AdvancedListingRules.UseDropRates.DisabledItemIDs", ""), "AdvancedListingRules.UseDropRates.DisabledItemIDs");
     MaxBuyoutPriceInCopper = sConfigMgr->GetOption<uint32>("AuctionHouseBot.MaxBuyoutPriceInCopper", 1000000000);


### PR DESCRIPTION
## Changes Proposed:
- Clear `AdvancedListingRuleUseDropRates<Category>AffectedQualities` during `InitializeConfiguration()`, like other Sets, to avoid `duplicate entries` error logging when an error has not occurred.
- Add note to `mod_ahbot.conf` to remind players of the behavior caused by `AllowTwoSide.Interaction.Auction` in AzerothCore

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- https://github.com/NathanHandley/mod-ah-bot/issues/42
- https://github.com/NathanHandley/mod-ah-bot/issues/43

## Tests Performed:
- Builds without errors
- After starting the server and performing `.ahbot reload`, there are no more duplicate entries errors logged. (If users duplicate entries in settings that take a list of itemIDs or "Affected Qualities", then the errors are still logged, which is the correct behavior)

