### PR TITLE
Fix build error: undefined reference to `Addmod_ah_bot_plusScripts()'

### DIFF
--- a/src/ah_bot_loader.cpp
+++ b/src/ah_bot_loader.cpp
@@ -8,7 +8,7 @@
 void AddAHBotScripts();
 
 // Add all
-void Addmod_ah_botScripts()
+void Addmod_ah_bot_plusScripts()
 {
     AddAHBotScripts();
 }


### PR DESCRIPTION
### Changes Proposed:
- Update the loader script to match the module rename

### Issues Addressed:  
Without this change, I get this error when building the worldserver:  
```
/bin/ld: ../../../modules/libmodules.a(ModulesLoader.cpp.o): in function `AddModulesScripts()':
ModulesLoader.cpp:(.text+0x7): undefined reference to `Addmod_ah_bot_plusScripts()'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
gmake[2]: *** [src/server/apps/CMakeFiles/worldserver.dir/build.make:197: src/server/apps/worldserver] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1149: src/server/apps/CMakeFiles/worldserver.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```

### Tests Performed:
- Builds now without errors (`.../azerothcore-wotlk/acore.sh compiler build`)
