### PR TITLE
Added mod-ah-bot backwards compatible script loader

### DIFF
--- a/src/ah_bot_loader.cpp
+++ b/src/ah_bot_loader.cpp
@@ -12,3 +12,8 @@ void Addmod_ah_bot_plusScripts()
 {
     AddAHBotScripts();
 }
+
+void Addmod_ah_botScripts()
+{
+    AddAHBotScripts();
+}


### PR DESCRIPTION
## Changes Proposed:
- Adds backwards compatibility handling for users that cloned `mod-ah-bot` before the repo name change

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/NathanHandley/mod-ah-bot-plus/issues/46

## Tests Performed:
- Builds without errors when the module director is either `mod-ah-bot` or `mod-ah-bot-plus`
- Server starts without issue and verified ahbot logging
