### PR TITLE
Fixed handling of null UseDropRates.<Category>.AffectedQualities configs. Improved module disablement

### DIFF
--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -1211,6 +1211,14 @@ void AuctionHouseBot::PopulateItemDropChances()
 
 void AuctionHouseBot::PopulateItemDropChancesForCategoryAndQuality(ItemClass category, std::string qualities)
 {
+    if (qualities.empty())
+    {
+        LOG_ERROR("module", "AuctionHouseBot: PopulateItemDropChancesForCategoryAndQuality() qualities are not set. "
+                            "Verify that mod_ahbot.conf has values for AdvancedListingRules.UseDropRates.<Category>.AffectedQualities. "
+                            "Defaulting to '2,3,4,5' to prevent crash.");
+        qualities = "2,3,4,5";
+    }
+
     // Search creature loot templates, referenced loot_loot_template, group_loot tables, and object_loot tables for items' drop rates
     std::string directDropString = R"SQL(
         with chances AS (
@@ -1799,24 +1807,30 @@ void AuctionHouseBot::Update()
         ObjectAccessor::RemoveObject(player.get());
 }
 
+bool AuctionHouseBot::IsModuleEnabled()
+{
+    bool sellerEnabled = sConfigMgr->GetOption<bool>("AuctionHouseBot.EnableSeller", false);
+    bool buyerEnabled = sConfigMgr->GetOption<bool>("AuctionHouseBot.Buyer.Enabled", false);
+    if (sellerEnabled == false && buyerEnabled == false)
+        return false;
+    string charString = sConfigMgr->GetOption<std::string>("AuctionHouseBot.GUIDs", "0");
+    if (charString == "0")
+    {
+        LOG_INFO("module", "AuctionHouseBot: AuctionHouseBot.GUIDs is '0' so this module will be disabled");
+        return false;
+    }
+    return true;
+}
+
 void AuctionHouseBot::InitializeConfiguration()
 {
     debug_Out = sConfigMgr->GetOption<bool>("AuctionHouseBot.DEBUG", false);
     debug_Out_Filters = sConfigMgr->GetOption<bool>("AuctionHouseBot.DEBUG_FILTERS", false);
 
-    // Bot enablement
     SellingBotEnabled = sConfigMgr->GetOption<bool>("AuctionHouseBot.EnableSeller", false);
     BuyingBotEnabled = sConfigMgr->GetOption<bool>("AuctionHouseBot.Buyer.Enabled", false);
-    if (SellingBotEnabled == false && BuyingBotEnabled == false)
-        return;
+
     string charString = sConfigMgr->GetOption<std::string>("AuctionHouseBot.GUIDs", "0");
-    if (charString == "0")
-    {
-        BuyingBotEnabled = false;
-        SellingBotEnabled = false;
-        LOG_INFO("module", "AuctionHouseBot: AuctionHouseBot.GUIDs is '0' so this module will be disabled");
-        return;
-    }
     AddCharacters(charString);
 
     // Buyer & Seller core properties

--- a/src/AuctionHouseBot.cpp
+++ b/src/AuctionHouseBot.cpp
@@ -1814,9 +1814,9 @@ bool AuctionHouseBot::IsModuleEnabled()
     if (sellerEnabled == false && buyerEnabled == false)
         return false;
     string charString = sConfigMgr->GetOption<std::string>("AuctionHouseBot.GUIDs", "0");
-    if (charString == "0")
+    if (charString == "0" || charString.empty())
     {
-        LOG_INFO("module", "AuctionHouseBot: AuctionHouseBot.GUIDs is '0' so this module will be disabled");
+        LOG_INFO("module", "AuctionHouseBot: AuctionHouseBot.GUIDs is not configured so this module will be disabled");
         return false;
     }
     return true;

--- a/src/AuctionHouseBot.h
+++ b/src/AuctionHouseBot.h
@@ -313,6 +313,7 @@ public:
     ~AuctionHouseBot();
 
     void Update();
+    bool IsModuleEnabled();
     void InitializeConfiguration();
     void EmptyAuctionHouses();
     uint32 GetRandomStackValue(std::string configKeyString, uint32 defaultValue);

--- a/src/AuctionHouseBotScript.cpp
+++ b/src/AuctionHouseBotScript.cpp
@@ -20,13 +20,16 @@ public:
 
     void OnAfterConfigLoad(bool /*reload*/) override
     {
+        if (!auctionbot->IsModuleEnabled())
+            return;
+
         auctionbot->InitializeConfiguration();
         if (HasPerformedStartup == true)
         {
             LOG_INFO("server.loading", "AuctionHouseBot: (Re)populating item candidate lists ...");
             auctionbot->PopulateItemCandidatesAndProportions();
 
-            if (sConfigMgr->GetOption<bool>("AuctionHouseBot.AdvancedListingRules.UseDropRates.Enabled", true))
+            if (sConfigMgr->GetOption<bool>("AuctionHouseBot.AdvancedListingRules.UseDropRates.Enabled", false))
             {
                 auctionbot->PopulateQuestRewardItemIDs();
                 auctionbot->PopulateItemDropChances();
@@ -36,9 +39,12 @@ public:
 
     void OnStartup() override
     {
+        if (!auctionbot->IsModuleEnabled())
+            return;
+
         LOG_INFO("server.loading", "AuctionHouseBot: (Re)populating item candidate lists ...");
         auctionbot->PopulateItemCandidatesAndProportions();
-        if (sConfigMgr->GetOption<bool>("AuctionHouseBot.AdvancedListingRules.UseDropRates.Enabled", true))
+        if (sConfigMgr->GetOption<bool>("AuctionHouseBot.AdvancedListingRules.UseDropRates.Enabled", false))
         {
             auctionbot->PopulateQuestRewardItemIDs();
             auctionbot->PopulateItemDropChances();


### PR DESCRIPTION
## Changes Proposed:
- Handle null `UseDropRates.<Category>.AffectedQualities` more gracefully and log error reminding user to check configuration
- Adds `IsModuleEnabled()` (moves a few checks from `InitializeConfiguration()` so the logic can be checked in `OnAfterConfigLoad()` and `OnStartup()` without duplicating code

## Issues Addressed:
- Closes #47 

## Tests Performed:
- Builds without errors
- Setting any of `UseDropRates.<Category>.AffectedQualities` to an empty string or no value gracefully proceeds with default values
- If both Buyer and Seller are disabled, the module does not load
- Similarly, if AuctionHouseBot.GUIDs is set to `0` or an empty string, the module does not load

---

> So either: Restructure things a little bit so that they don't run unless the mod is enabled (AHCharacters is not empty AND either SellerBotEnabled or BuyingBotEnabled is true) or default "UseDropRates.Enabled" as false or give a default qualities list in PopulateItemDropChancesForCategoryAndQuality when empty.

I know you outlined a few "OR" ways of handling this, but I thought it might be good to overhaul a few different spots just in case.   Is this roughly what you had in mind?